### PR TITLE
Async Activation Check

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -28,7 +28,7 @@ permissions:
 env:
   # Go language version to use for building. This value should also be updated
   # in the testing workflow if changed.
-  GO_VERSION: '1.19'
+  GO_VERSION: '1.21'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/apex/models/activation_model.go
+++ b/apex/models/activation_model.go
@@ -26,3 +26,13 @@ type ActivationClientModel struct {
 	Password types.String `tfsdk:"password"`
 	Scheme   types.String `tfsdk:"scheme"`
 }
+
+// ActivationAsyncClientModel defines the attribute names and types for a PowerFlex Client TF model
+type ActivationAsyncClientModel struct {
+	Host         types.String `tfsdk:"host"`
+	Insecure     types.Bool   `tfsdk:"insecure"`
+	Username     types.String `tfsdk:"username"`
+	Password     types.String `tfsdk:"password"`
+	Scheme       types.String `tfsdk:"scheme"`
+	PollInterval types.Int64  `tfsdk:"poll_interval"`
+}

--- a/apex/models/mobility_groups_copy_model.go
+++ b/apex/models/mobility_groups_copy_model.go
@@ -22,10 +22,10 @@ import (
 
 // MobilityGroupCopyModel defines the attribute names and types for a Mobility Target TF model
 type MobilityGroupCopyModel struct {
-	ID                    types.String           `tfsdk:"id"`
-	MobilitySourceID      types.String           `tfsdk:"mobility_source_id"`
-	MobilityTargetID      types.String           `tfsdk:"mobility_target_id"`
-	Status                types.String           `tfsdk:"status"`
-	PowerFlexClientSource *ActivationClientModel `tfsdk:"powerflex_source"`
-	PowerFlexClientTarget *ActivationClientModel `tfsdk:"powerflex_target"`
+	ID                    types.String                `tfsdk:"id"`
+	MobilitySourceID      types.String                `tfsdk:"mobility_source_id"`
+	MobilityTargetID      types.String                `tfsdk:"mobility_target_id"`
+	Status                types.String                `tfsdk:"status"`
+	PowerFlexClientSource *ActivationAsyncClientModel `tfsdk:"powerflex_source"`
+	PowerFlexClientTarget *ActivationAsyncClientModel `tfsdk:"powerflex_target"`
 }

--- a/apex/provider/powerflex_schema.go
+++ b/apex/provider/powerflex_schema.go
@@ -19,6 +19,7 @@ package provider
 import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 )
 
@@ -55,6 +56,50 @@ var PowerflexInfo schema.Schema = schema.Schema{
 			Description:         "Host, ip or hostname of the powerflex. If left empty we will attempt to get the ip through Apex from the ID",
 			Optional:            true,
 			Computed:            true,
+		},
+	},
+}
+
+// PowerflexAsyncInfo Schema defines tha acceptable confirguation and state attribute names and types
+var PowerflexAsyncInfo schema.Schema = schema.Schema{
+	Attributes: map[string]schema.Attribute{
+		"username": schema.StringAttribute{
+			MarkdownDescription: "Username of the powerflex",
+			Description:         "Username of the powerflex",
+			Required:            true,
+		},
+		"password": schema.StringAttribute{
+			MarkdownDescription: "Password of the powerflex",
+			Description:         "Password of the powerflex",
+			Sensitive:           true,
+			Required:            true,
+		},
+		"insecure": schema.BoolAttribute{
+			MarkdownDescription: "Validated the certificate when connecting to the powerflex, defaults if unset to true",
+			Description:         "Validated the certificate when connecting to the powerflex, defaults if unset to true",
+			Optional:            true,
+			Computed:            true,
+			Default:             booldefault.StaticBool(true),
+		},
+		"scheme": schema.StringAttribute{
+			MarkdownDescription: "Scheme of the powerflex, defaults if unset to https",
+			Description:         "Scheme of the powerflex, defaults if unset to https",
+			Optional:            true,
+			Computed:            true,
+			Default:             stringdefault.StaticString("https"),
+		},
+		"host": schema.StringAttribute{
+			MarkdownDescription: "Host, ip or hostname of the powerflex. If left empty we will attempt to get the ip through Apex from the ID",
+			Description:         "Host, ip or hostname of the powerflex. If left empty we will attempt to get the ip through Apex from the ID",
+			Optional:            true,
+			Computed:            true,
+		},
+		"poll_interval": schema.Int64Attribute{
+			MarkdownDescription: "Poll interval for long-running operations in seconds. This will check if the powerflex is activated every interval. Defaults if unset to 30",
+			Description:         "Poll interval for long-running operations in seconds. This will check if the powerflex is activated every interval. Defaults if unset to 30",
+			Optional:            true,
+			Computed:            true,
+			Default:             int64default.StaticInt64(30),
 		},
 	},
 }

--- a/apex/provider/provider.go
+++ b/apex/provider/provider.go
@@ -184,7 +184,7 @@ func (p *myProvider) Configure(ctx context.Context, req provider.ConfigureReques
 	// Make the cirrus client available during DataSource and Resource
 	// Make the Apex Navigator client available during DataSource and Resource
 	resp.DataSourceData = apiClients.APIClient
-	resp.ResourceData = apiClients
+	resp.ResourceData = Clients{APIClient: apiClients.APIClient, JMSClient: apiClients.JMSClient}
 }
 
 // DataSources defines the data sources implemented in the provider.

--- a/apex/provider/provider_test.go
+++ b/apex/provider/provider_test.go
@@ -82,7 +82,7 @@ func init() {
 	}
 
 	host := os.Getenv("APEX_HOST")
-	token := setDefault(os.Getenv("APEX_TOKEN"), "test_token")
+	token := setDefault(os.Getenv("APEX_TOKEN"), "123456789101112131415161718192021222324252627282930")
 
 	ProviderConfig = fmt.Sprintf(` 
 		provider "apex" {

--- a/apex/provider/resource_navigator_block_mobility_groups_copy_test.go
+++ b/apex/provider/resource_navigator_block_mobility_groups_copy_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAccResourceMobilityGroupsCopy(t *testing.T) {
+func TestAccResourceMobilityGroupsCopyR(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -110,12 +110,14 @@ resource "apex_navigator_block_mobility_groups_copy" "example" {
 		password = "` + powerflexPass + `"
 		scheme   = "` + powerflexScheme + `" 
 		insecure = "true"
+		poll_interval = "0"
 	}
 	powerflex_target {
 		username = "` + powerflexTargetUser + `"
 		password = "` + powerflexTargetPass + `"
 		scheme   = "` + powerflexScheme + `" 
 		insecure = "true"
+		poll_interval = "0"
 	}
   }
 

--- a/docs/resources/navigator_block_mobility_groups_copy.md
+++ b/docs/resources/navigator_block_mobility_groups_copy.md
@@ -42,6 +42,7 @@ Optional:
 
 - `host` (String) Host, ip or hostname of the powerflex. If left empty we will attempt to get the ip through Apex from the ID
 - `insecure` (Boolean) Validated the certificate when connecting to the powerflex, defaults if unset to true
+- `poll_interval` (Number) Poll interval for long-running operations in seconds. This will check if the powerflex is activated every interval. Defaults if unset to 30
 - `scheme` (String) Scheme of the powerflex, defaults if unset to https
 
 
@@ -57,4 +58,5 @@ Optional:
 
 - `host` (String) Host, ip or hostname of the powerflex. If left empty we will attempt to get the ip through Apex from the ID
 - `insecure` (Boolean) Validated the certificate when connecting to the powerflex, defaults if unset to true
+- `poll_interval` (Number) Poll interval for long-running operations in seconds. This will check if the powerflex is activated every interval. Defaults if unset to 30
 - `scheme` (String) Scheme of the powerflex, defaults if unset to https


### PR DESCRIPTION
# Description
- During the Copy Resource allow the Activation to do an async check every 30 seconds to see if the Powerflex or PowerScale token is still active
- Added an expiration check, if the token is being check and it will expire in less the 5 minutes go ahead and get a new token and update with Apex.

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Acceptance tests

```
=== RUN   TestAccResourceMobilityGroupsCopyR
--- PASS: TestAccResourceMobilityGroupsCopyR (15.42s)
=== RUN   TestAccResourceMobilityGroupsCopyError
--- PASS: TestAccResourceMobilityGroupsCopyError (48.62s)
PASS
ok      github.com/dell/terraform-provider-apex/apex/provider   66.88
```