### PR TITLE
Remove JWT_TOKEN from examples

### DIFF
--- a/apex/test_utils/terraform_datasource_get_test_id.tf
+++ b/apex/test_utils/terraform_datasource_get_test_id.tf
@@ -29,13 +29,10 @@ terraform {
 
 provider "apex" {
   host  = var.HOST
-  token = var.JWT_TOKEN
+  
 }
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,15 +32,11 @@ limitations under the License.
 
 provider "apex" {
   host         = var.HOST
-  token        = var.JWT_TOKEN
   jms_endpoint = var.JMS_ENDPOINT
   insecure     = true
 }
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/data-sources/navigator_aws_accounts/provider.tf
+++ b/examples/data-sources/navigator_aws_accounts/provider.tf
@@ -23,6 +23,6 @@ terraform {
 }
 
 provider "apex" {
-  host  = var.HOST
-  token = var.JWT_TOKEN
+  host = var.HOST
+
 }

--- a/examples/data-sources/navigator_aws_accounts/variables.tf
+++ b/examples/data-sources/navigator_aws_accounts/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/data-sources/navigator_aws_permissions/provider.tf
+++ b/examples/data-sources/navigator_aws_permissions/provider.tf
@@ -23,6 +23,5 @@ terraform {
 }
 
 provider "apex" {
-  host  = var.HOST
-  token = var.JWT_TOKEN
+  host = var.HOST
 }

--- a/examples/data-sources/navigator_aws_permissions/variables.tf
+++ b/examples/data-sources/navigator_aws_permissions/variables.tf
@@ -15,10 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
 
 variable "HOST" {
   type    = string

--- a/examples/data-sources/navigator_block_clones/provider.tf
+++ b/examples/data-sources/navigator_block_clones/provider.tf
@@ -24,6 +24,5 @@ terraform {
 
 provider "apex" {
   host     = var.HOST
-  token    = var.JWT_TOKEN
   insecure = true
 }

--- a/examples/data-sources/navigator_block_clones/variables.tf
+++ b/examples/data-sources/navigator_block_clones/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/data-sources/navigator_block_hosts/provider.tf
+++ b/examples/data-sources/navigator_block_hosts/provider.tf
@@ -24,6 +24,5 @@ terraform {
 
 provider "apex" {
   host     = var.HOST
-  token    = var.JWT_TOKEN
   insecure = true
 }

--- a/examples/data-sources/navigator_block_hosts/variables.tf
+++ b/examples/data-sources/navigator_block_hosts/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/data-sources/navigator_block_mobility_groups/provider.tf
+++ b/examples/data-sources/navigator_block_mobility_groups/provider.tf
@@ -24,6 +24,5 @@ terraform {
 
 provider "apex" {
   host     = var.HOST
-  token    = var.JWT_TOKEN
   insecure = true
 }

--- a/examples/data-sources/navigator_block_mobility_groups/variables.tf
+++ b/examples/data-sources/navigator_block_mobility_groups/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/data-sources/navigator_block_mobility_targets/provider.tf
+++ b/examples/data-sources/navigator_block_mobility_targets/provider.tf
@@ -24,6 +24,5 @@ terraform {
 
 provider "apex" {
   host     = var.HOST
-  token    = var.JWT_TOKEN
   insecure = true
 }

--- a/examples/data-sources/navigator_block_mobility_targets/variables.tf
+++ b/examples/data-sources/navigator_block_mobility_targets/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/data-sources/navigator_block_storage_pools/provider.tf
+++ b/examples/data-sources/navigator_block_storage_pools/provider.tf
@@ -24,6 +24,5 @@ terraform {
 
 provider "apex" {
   host     = var.HOST
-  token    = var.JWT_TOKEN
   insecure = true
 }

--- a/examples/data-sources/navigator_block_storage_pools/variables.tf
+++ b/examples/data-sources/navigator_block_storage_pools/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/data-sources/navigator_block_volume/provider.tf
+++ b/examples/data-sources/navigator_block_volume/provider.tf
@@ -24,6 +24,5 @@ terraform {
 
 provider "apex" {
   host     = var.HOST
-  token    = var.JWT_TOKEN
   insecure = true
 }

--- a/examples/data-sources/navigator_block_volume/variables.tf
+++ b/examples/data-sources/navigator_block_volume/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/data-sources/navigator_storage/provider.tf
+++ b/examples/data-sources/navigator_storage/provider.tf
@@ -24,6 +24,5 @@ terraform {
 
 provider "apex" {
   host     = var.HOST
-  token    = var.JWT_TOKEN
   insecure = true
 }

--- a/examples/data-sources/navigator_storage/variables.tf
+++ b/examples/data-sources/navigator_storage/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -24,15 +24,12 @@ terraform {
 }
 
 provider "apex" {
-  host         = var.HOST
-  token        = var.JWT_TOKEN
+  host = var.HOST
+
   jms_endpoint = var.JMS_ENDPOINT
 }
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/provider.tfvars
+++ b/examples/provider.tfvars
@@ -17,4 +17,3 @@ limitations under the License.
 
 HOST         = "https://example.com"
 JMS_ENDPOINT = "https://example-JMS.com"
-JWT_TOKEN    = ""

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -17,15 +17,11 @@ limitations under the License.
 
 provider "apex" {
   host         = var.HOST
-  token        = var.JWT_TOKEN
   jms_endpoint = var.JMS_ENDPOINT
   insecure     = true
 }
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/resource/navigator_aws_account/provider.tf
+++ b/examples/resource/navigator_aws_account/provider.tf
@@ -23,7 +23,7 @@ terraform {
 }
 
 provider "apex" {
-  host         = var.HOST
-  token        = var.JWT_TOKEN
+  host = var.HOST
+
   jms_endpoint = var.JMS_ENDPOINT
 }

--- a/examples/resource/navigator_aws_account/variables.tf
+++ b/examples/resource/navigator_aws_account/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/resource/navigator_aws_generate_trust_policy/provider.tf
+++ b/examples/resource/navigator_aws_generate_trust_policy/provider.tf
@@ -24,7 +24,6 @@ terraform {
 
 provider "apex" {
   host         = var.HOST
-  token        = var.JWT_TOKEN
   jms_endpoint = var.JMS_ENDPOINT
   insecure     = true
 }

--- a/examples/resource/navigator_aws_generate_trust_policy/variables.tf
+++ b/examples/resource/navigator_aws_generate_trust_policy/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/resource/navigator_block_clones/provider.tf
+++ b/examples/resource/navigator_block_clones/provider.tf
@@ -24,7 +24,6 @@ terraform {
 
 provider "apex" {
   host         = var.HOST
-  token        = var.JWT_TOKEN
   jms_endpoint = var.JMS_ENDPOINT
   insecure     = true
 }

--- a/examples/resource/navigator_block_clones/variables.tf
+++ b/examples/resource/navigator_block_clones/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/resource/navigator_block_clones_map/provider.tf
+++ b/examples/resource/navigator_block_clones_map/provider.tf
@@ -24,7 +24,6 @@ terraform {
 
 provider "apex" {
   host         = var.HOST
-  token        = var.JWT_TOKEN
   jms_endpoint = var.JMS_ENDPOINT
   insecure     = true
 }

--- a/examples/resource/navigator_block_clones_map/variables.tf
+++ b/examples/resource/navigator_block_clones_map/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/resource/navigator_block_clones_refresh/provider.tf
+++ b/examples/resource/navigator_block_clones_refresh/provider.tf
@@ -24,7 +24,6 @@ terraform {
 
 provider "apex" {
   host         = var.HOST
-  token        = var.JWT_TOKEN
   jms_endpoint = var.JMS_ENDPOINT
   insecure     = true
 }

--- a/examples/resource/navigator_block_clones_refresh/variables.tf
+++ b/examples/resource/navigator_block_clones_refresh/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/resource/navigator_block_clones_unmap/provider.tf
+++ b/examples/resource/navigator_block_clones_unmap/provider.tf
@@ -24,7 +24,6 @@ terraform {
 
 provider "apex" {
   host         = var.HOST
-  token        = var.JWT_TOKEN
   jms_endpoint = var.JMS_ENDPOINT
   insecure     = true
 }

--- a/examples/resource/navigator_block_clones_unmap/variables.tf
+++ b/examples/resource/navigator_block_clones_unmap/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/resource/navigator_block_mobility-groups/provider.tf
+++ b/examples/resource/navigator_block_mobility-groups/provider.tf
@@ -24,7 +24,6 @@ terraform {
 
 provider "apex" {
   host         = var.HOST
-  token        = var.JWT_TOKEN
   jms_endpoint = var.JMS_ENDPOINT
   insecure     = true
 }

--- a/examples/resource/navigator_block_mobility-targets/provider.tf
+++ b/examples/resource/navigator_block_mobility-targets/provider.tf
@@ -24,7 +24,6 @@ terraform {
 
 provider "apex" {
   host         = var.HOST
-  token        = var.JWT_TOKEN
   jms_endpoint = var.JMS_ENDPOINT
   insecure     = true
 }

--- a/examples/resource/navigator_block_mobility-targets/variables.tf
+++ b/examples/resource/navigator_block_mobility-targets/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/resource/navigator_block_mobility_groups_copy/provider.tf
+++ b/examples/resource/navigator_block_mobility_groups_copy/provider.tf
@@ -24,7 +24,6 @@ terraform {
 
 provider "apex" {
   host         = var.HOST
-  token        = var.JWT_TOKEN
   jms_endpoint = var.JMS_ENDPOINT
   insecure     = true
 }

--- a/examples/resource/navigator_block_mobility_groups_copy/variables.tf
+++ b/examples/resource/navigator_block_mobility_groups_copy/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/resource/navigator_block_storage_cloud/provider.tf
+++ b/examples/resource/navigator_block_storage_cloud/provider.tf
@@ -24,7 +24,6 @@ terraform {
 
 provider "apex" {
   host         = var.HOST
-  token        = var.JWT_TOKEN
   jms_endpoint = var.JMS_ENDPOINT
   insecure     = true
 }

--- a/examples/resource/navigator_block_storage_cloud/variables.tf
+++ b/examples/resource/navigator_block_storage_cloud/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string

--- a/examples/resource/navigator_file_storage_cloud/provider.tf
+++ b/examples/resource/navigator_file_storage_cloud/provider.tf
@@ -24,7 +24,6 @@ terraform {
 
 provider "apex" {
   host         = var.HOST
-  token        = var.JWT_TOKEN
   jms_endpoint = var.JMS_ENDPOINT
   insecure     = true
 }

--- a/examples/resource/navigator_file_storage_cloud/variables.tf
+++ b/examples/resource/navigator_file_storage_cloud/variables.tf
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "JWT_TOKEN" {
-  type    = string
-  default = "insert-token-here"
-}
+
 
 variable "HOST" {
   type    = string


### PR DESCRIPTION
# Description
remove the JWT_TOKEN reference from the examples since this does not work in production. 

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Acceptance tests