### PR TITLE
Fix AWS Account Connection Update issue

### DIFF
--- a/apex/provider/resource_navigator_aws_account.go
+++ b/apex/provider/resource_navigator_aws_account.go
@@ -197,22 +197,12 @@ func (r *awsAccountResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	// Update the account
-	updateJob, status, err := helper.UpdateAccount(r.client, plan.AccountID.ValueString(), plan.RoleArn.ValueString())
-	if err != nil || status == nil || status.StatusCode != http.StatusOK {
+	_, status, err := helper.UpdateAccount(r.client, plan.AccountID.ValueString(), plan.RoleArn.ValueString())
+	if err != nil || status == nil || status.StatusCode != http.StatusNoContent {
 		newErr := helper.GetErrorString(err, status)
 		resp.Diagnostics.AddError(
 			constants.AwsAccountUpdateErrorMsg,
 			constants.AwsAccountUpdateErrorMsg+newErr,
-		)
-		return
-	}
-
-	// Fetching Job Status
-	_, jobErr := helper.WaitForJobToComplete(ctx, r.jobsClient, updateJob.Id)
-	if jobErr != nil {
-		resp.Diagnostics.AddError(
-			constants.UpdateJobErrorMsg,
-			constants.GeneralJobError+jobErr.Error(),
 		)
 		return
 	}

--- a/apex/provider/resource_navigator_aws_account_test.go
+++ b/apex/provider/resource_navigator_aws_account_test.go
@@ -93,17 +93,6 @@ func TestAccResourceAwsAccountErrorTesting(t *testing.T) {
 				Config:      ProviderConfig + awsAccountResourceUpdateConfig,
 				ExpectError: regexp.MustCompile(".*Unable to Read Apex Navigator Aws Accounts*"),
 			},
-			// Job Error
-			{
-				PreConfig: func() {
-					if FunctionMocker != nil {
-						FunctionMocker.UnPatch()
-					}
-					FunctionMocker = Mock(helper.WaitForJobToComplete).Return(nil, fmt.Errorf("Mock error")).Build()
-				},
-				Config:      ProviderConfig + awsAccountResourceUpdateConfig,
-				ExpectError: regexp.MustCompile(".*Error occurred during update job*"),
-			},
 			// Update Error
 			{
 				PreConfig: func() {


### PR DESCRIPTION
# Description
- AWS Account Update does not return a job, it returns a 204 No Content

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Acceptance tests